### PR TITLE
add: 新規フィード追加

### DIFF
--- a/src/resources/feed-info-list.ts
+++ b/src/resources/feed-info-list.ts
@@ -518,7 +518,7 @@ export const FEED_INFO_LIST: FeedInfo[] = createFeedInfoList([
   ['遊舎工房', 'https://blog.yushakobo.jp/feed'],
   ['電通国際情報サービス', 'https://tech.isid.co.jp/feed'],
   ['食べチョク', 'https://tech.tabechoku.com/feed'],
-  ['食べログ', 'https://note.com/tabelog_frontend/rss'],
+  ['食べログ', 'https://tech-blog.tabelog.com/feed'],
   ['ＦＦＲＩセキュリティ', 'https://engineers.ffri.jp/feed'],
   ['note', 'https://engineerteam.note.jp/m/m70da42dac8cf/rss'],
 ]);


### PR DESCRIPTION
食べログの開発者ブログが移転したので、既存の feed URL を更新