### PR TITLE
update: clusterのブログをnoteからはてなブログへ移動

### DIFF
--- a/src/resources/feed-info-list.ts
+++ b/src/resources/feed-info-list.ts
@@ -56,7 +56,7 @@ export const FEED_INFO_LIST: FeedInfo[] = createFeedInfoList([
   ['Cerevo', 'https://tech-blog.cerevo.com/feed'],
   ['Chatwork', 'https://creators-note.chatwork.com/feed'],
   ['Classi', 'https://tech.classi.jp/feed'],
-  ['Cluster', 'https://note.com/cluster_official/m/m2ad487750b4e/rss'],
+  ['Cluster', 'https://tech-blog.cluster.mu/rss'],
   ['Colorful Palette', 'https://media.colorfulpalette.co.jp/m/m753f507dae79/rss'],
   ['ContractS', 'https://tech.contracts.co.jp/feed'],
   ['Croooober', 'https://tech.croooober.co.jp/feed'],


### PR DESCRIPTION
はてなブログへ引っ越しているのでURLを更新しました。
https://note.com/cluster_official/n/n8f8b53817edd
<img src="https://user-images.githubusercontent.com/233012/226810527-55364008-fbaa-4dda-bc06-bb7f7eaf952b.png" width="50%"/>

