### PR TITLE
update: Tier IV さんの feed の変更

### DIFF
--- a/src/resources/feed-info-list.ts
+++ b/src/resources/feed-info-list.ts
@@ -208,7 +208,7 @@ export const FEED_INFO_LIST: FeedInfo[] = createFeedInfoList([
   ['TeamSpirit', 'https://teamspirit.hatenablog.com/feed'],
   ['TechRacho', 'https://techracho.bpsinc.jp/feed'],
   ['TechTrain', 'https://zenn.dev/techtrain/feed'],
-  ['Tier IV', 'https://tech.tier4.jp/feed'],
+  ['Tier IV', 'https://medium.com/feed/tier-iv-tech-blog/tagged/tech-blog'],
   ['Tokyo Otaku Mode', 'https://blog.otakumode.com/atom.xml'],
   ['UUUM', 'https://system.blog.uuum.jp/feed'],
   ['Ubie', 'https://zenn.dev/ubie/feed'],


### PR DESCRIPTION
Tier IV さんのテックブログが移転していることに気づいたので PR です（わたしは Tier IV さんと関係はありません）

はてなブログから Medium に移行した証拠: https://tech.tier4.jp/entry/2022/06/02/164026
Medium のブログ: https://medium.com/tier-iv-tech-blog/tagged/tech-blog