### PR TITLE
fix: rss-parserのparseURLを使うとリダイレクト時にプロセスが終わらないことがあるのでparseStringするように

### DIFF
--- a/src/feed/utils/common-util.ts
+++ b/src/feed/utils/common-util.ts
@@ -54,20 +54,20 @@ export const isValidHttpUrl = (url: string) => {
   return urlObject.protocol === 'http:' || urlObject.protocol === 'https:';
 };
 
-export const exponentialBackoff = async <A>(retrier: () => Promise<A>, retries = 3) => {
+export const exponentialBackoff = async <A>(retrier: (attemptCount: number) => Promise<A>, retries = 3) => {
   let attemptLimitReached = false;
-  let attemptNumber = 0;
+  let attemptCount = 0;
 
   while (!attemptLimitReached) {
-    const [error, result] = await to(retrier());
+    const [error, result] = await to(retrier(attemptCount));
     if (error) {
-      attemptNumber++;
-      attemptLimitReached = attemptNumber > retries;
+      attemptCount++;
+      attemptLimitReached = attemptCount > retries;
 
       if (attemptLimitReached) {
         throw error;
       } else {
-        const waitTime = Math.pow(2, attemptNumber) * 1000;
+        const waitTime = Math.pow(2, attemptCount) * 1000;
         await sleep(waitTime);
       }
     } else {

--- a/src/feed/utils/feed-crawler.ts
+++ b/src/feed/utils/feed-crawler.ts
@@ -74,8 +74,18 @@ export class FeedCrawler {
       .withConcurrency(concurrency)
       .process(async (feedInfo) => {
         const [error, feed] = await to(
-          exponentialBackoff(() => {
-            return this.rssParser.parseURL(feedInfo.url) as Promise<CustomRssParserFeed>;
+          exponentialBackoff(async (attemptCount: number) => {
+            if (attemptCount > 0) {
+              logger.warn(`[fetch-feed] retry ${feedInfo.url}`);
+            }
+
+            const response = await fetch(feedInfo.url);
+            if (!response.ok) {
+              throw new Error(`HTTP Error: ${response.status}`);
+            }
+
+            const feedData = await response.text();
+            return this.rssParser.parseString(feedData);
           }),
         );
         if (error) {
@@ -258,7 +268,11 @@ export class FeedCrawler {
       .withConcurrency(concurrency)
       .process(async (feedItem) => {
         const [error, ogsResult] = await to(
-          exponentialBackoff(() => {
+          exponentialBackoff((attemptCount: number) => {
+            if (attemptCount > 0) {
+              logger.warn(`[fetch-feed-item-og] retry ${feedItem.link}`);
+            }
+
             return FeedCrawler.fetchOgsResult(feedItem.link);
           }),
         );
@@ -291,7 +305,11 @@ export class FeedCrawler {
       .withConcurrency(concurrency)
       .process(async (feed) => {
         const [error, ogsResult] = await to(
-          exponentialBackoff(() => {
+          exponentialBackoff((attemptCount: number) => {
+            if (attemptCount > 0) {
+              logger.warn(`[fetch-feed-blog-og] retry ${feed.link}`);
+            }
+
             return FeedCrawler.fetchOgsResult(feed.link);
           }),
         );

--- a/src/feed/utils/feed-crawler.ts
+++ b/src/feed/utils/feed-crawler.ts
@@ -85,7 +85,7 @@ export class FeedCrawler {
             }
 
             const feedData = await response.text();
-            return this.rssParser.parseString(feedData);
+            return this.rssParser.parseString(feedData) as Promise<CustomRssParserFeed>;
           }),
         );
         if (error) {

--- a/tests/feed-info-list.test.ts
+++ b/tests/feed-info-list.test.ts
@@ -34,26 +34,3 @@ describe('フィードが取得可能', () => {
     );
   });
 });
-
-// リダイレクトされないテスト
-// rss-parser がリダイレクトするURLだとハングするため
-describe('リダイレクトされない', () => {
-  FEED_INFO_LIST.map((feedInfo: FeedInfo) => {
-    const testTitle = `${feedInfo.label} / ${feedInfo.url}`;
-    it.concurrent(
-      testTitle,
-      async () => {
-        const [error, response] = await to(fetch(feedInfo.url, { redirect: 'manual' }));
-        // リダイレクトしていないことを確認
-        expect(error).toBeNull();
-        expect(response).not.toBeNull();
-        if (response) {
-          const rerirectTo = response.headers.get('location');
-          expect(response.status, `Redirected to: ${rerirectTo}`).not.toEqual(301);
-          expect(response.status, `Redirected to: ${rerirectTo}`).not.toEqual(302);
-        }
-      },
-      180 * 1000,
-    );
-  });
-});

--- a/tests/feed-info-list.test.ts
+++ b/tests/feed-info-list.test.ts
@@ -3,7 +3,6 @@ import { FeedCrawler } from '../src/feed/utils/feed-crawler';
 import { describe, it, expect } from 'vitest';
 import { exponentialBackoff } from '../src/feed/utils/common-util';
 import RssParser from 'rss-parser';
-import { to } from 'await-to-js';
 
 const rssParser = new RssParser({
   maxRedirects: 0,


### PR DESCRIPTION
fix: #66 

## やったこと
parseStringのお試し。

- rss-parser parseUrl() していたのを、fetch() + parseString() に変更
- リトライ時にwarnログを出す

リダイレクトするURLがある場合、私のローカルでは100%プロセスが終わらないことをまず確認しいていて、この修正で治ることも確認。

## 確認事項
以下それぞれのブランチでgenerateジョブを何度か実行し、再現と修正を確認する
- 修正前の状態のCIの確認ブランチ
  - tmp/check-redirect-hang
  - https://github.com/yamadashy/tech-blog-rss-feed/actions/runs/7594627565
- 修正後の状態はこのPRで確認ブランチ
  - tmp/check-redirect-hang-fixed
  - https://github.com/yamadashy/tech-blog-rss-feed/actions/runs/7594622668

