### PR TITLE
webpをなくしてavif, jpegだけにする。その他改善

### DIFF
--- a/eleventy.config.ts
+++ b/eleventy.config.ts
@@ -47,7 +47,7 @@ const imageThumbnailShortcode = async (src: string, alt: string, pathPrefix = ''
       cacheOptions: imageCacheOptions,
       sharpAvifOptions: {
         quality: 35,
-        effort: 5,
+        effort: 4,
       },
       sharpJpegOptions: {
         quality: 70,

--- a/eleventy.config.ts
+++ b/eleventy.config.ts
@@ -28,7 +28,7 @@ const minifyHtmlTransform = (content: string, outputPath: string) => {
   return content;
 };
 
-const imageThumbnailShortcode = async (src: string, alt: string, pathPrefix = '') => {
+const imageThumbnailShortcode = async (src: string, alt: string, pathPrefix = '', imageLoading = 'lazy') => {
   // 取れなければ代替画像
   const alternativeImageTag = `<img src='${pathPrefix}images/alternate-feed-image.png' alt='${alt}' loading='lazy' width='256' height='256'>`;
 
@@ -62,12 +62,11 @@ const imageThumbnailShortcode = async (src: string, alt: string, pathPrefix = ''
   return EleventyImage.generateHTML(metadata, {
     alt,
     sizes: '100vw',
-    loading: 'lazy',
-    decoding: 'async',
+    loading: imageLoading,
   });
 };
 
-const imageIconShortcode = async (src: string, alt: string, pathPrefix = '') => {
+const imageIconShortcode = async (src: string, alt: string, pathPrefix = '', imageLoading = 'lazy') => {
   // 取れなければ画像なし
   const alternativeImageTag = '';
 
@@ -122,8 +121,7 @@ const imageIconShortcode = async (src: string, alt: string, pathPrefix = '') => 
 
   return EleventyImage.generateHTML(metadata, {
     alt,
-    loading: 'lazy',
-    decoding: 'async',
+    loading: imageLoading,
   });
 };
 

--- a/eleventy.config.ts
+++ b/eleventy.config.ts
@@ -41,18 +41,13 @@ const imageThumbnailShortcode = async (src: string, alt: string, pathPrefix = ''
   try {
     metadata = await EleventyImage(src, {
       widths: [150, 450],
-      formats: ['avif', 'webp', 'jpeg'],
+      formats: ['avif', 'jpeg'],
       outputDir: 'public/images/feed-thumbnails',
       urlPath: `${pathPrefix}images/feed-thumbnails/`,
       cacheOptions: imageCacheOptions,
       sharpAvifOptions: {
         quality: 35,
         effort: 5,
-      },
-      sharpWebpOptions: {
-        quality: 50,
-        effort: 5,
-        smartSubsample: true,
       },
       sharpJpegOptions: {
         quality: 70,

--- a/src/site/_includes/layouts/main.njk
+++ b/src/site/_includes/layouts/main.njk
@@ -41,22 +41,6 @@
 
     <link rel="stylesheet" type="text/css" href="{{ page.url | relativeUrl }}styles/bundle.css" />
 
-    {% if constants.globalSiteTagKey %}
-        <!-- Global site tag (gtag.js) - Google Analytics -->
-        <script async src="https://www.googletagmanager.com/gtag/js?id={{ constants.globalSiteTagKey }}"></script>
-        <script>
-          window.dataLayer = window.dataLayer || [];
-
-          function gtag() {
-            dataLayer.push(arguments);
-          }
-
-          gtag('js', new Date());
-
-          gtag('config', '{{ constants.globalSiteTagKey }}');
-        </script>
-    {% endif %}
-
     <title>{{ pageTitle }}</title>
 </head>
 <body>
@@ -110,6 +94,22 @@
             </div>
         </div>
     </footer>
+
+    {% if constants.globalSiteTagKey %}
+        <!-- Global site tag (gtag.js) - Google Analytics -->
+        <script async src="https://www.googletagmanager.com/gtag/js?id={{ constants.globalSiteTagKey }}"></script>
+        <script>
+          window.dataLayer = window.dataLayer || [];
+
+          function gtag() {
+            dataLayer.push(arguments);
+          }
+
+          gtag('js', new Date());
+
+          gtag('config', '{{ constants.globalSiteTagKey }}');
+        </script>
+    {% endif %}
 
 </body>
 </html>

--- a/src/site/_includes/layouts/partials/feed-item.njk
+++ b/src/site/_includes/layouts/partials/feed-item.njk
@@ -1,22 +1,22 @@
 <div class='ui-feed-item'>
     <a class='ui-feed-item__og-image' href='{{ feedItem.url }}'>
         {% if feedItem.image %}
-            {% imageThumbnail feedItem.image.url, '記事のアイキャッチ画像', page.url | relativeUrl %}
+            {% imageThumbnail feedItem.image.url, '記事のアイキャッチ画像', page.url | relativeUrl, imageLoading %}
         {% else %}
-            <img src='{{ page.url | relativeUrl }}images/alternate-feed-image.png' loading="lazy" alt='記事のアイキャッチ画像' width='256' height='256'>
+            <img src='{{ page.url | relativeUrl }}images/alternate-feed-image.png' loading="eager" alt='記事のアイキャッチ画像' width='256' height='256'>
         {% endif %}
     </a>
     <div class='ui-feed-item__content'>
         <a class='ui-feed-item__title' href='{{ feedItem.url }}'>{{ feedItem._custom.originalTitle }}</a>
         {% if feedItem._custom.hatenaCount > 0 %}
             <div class='ui-feed-item__hatena-count' title='はてなブックマーク数'>
-                <img src='{{ page.url | relativeUrl }}images/hatenabookmark-icon.png' alt='はてなブックマークアイコン' loading="lazy" width='16' height='16'>
+                <img src='{{ page.url | relativeUrl }}images/hatenabookmark-icon.png' alt='はてなブックマークアイコン' loading="eager" width='16' height='16'>
                 <span>{{ feedItem._custom.hatenaCount }}</span>
             </div>
         {% endif %}
         <a class='ui-feed-item__blog-title ui-feed-item__blog-title--link' href='{{ page.url | relativeUrl }}blogs/{{ feedItem._custom.blogLinkMd5Hash }}'>
           {% if feedItem._custom.favicon %}
-            {% imageIcon feedItem._custom.favicon, 'ブログのファビコン', page.url | relativeUrl %}
+            {% imageIcon feedItem._custom.favicon, 'ブログのファビコン', page.url | relativeUrl, imageLoading %}
           {% endif %}
           <span>{{ feedItem._custom.blogTitle }}</span>
         </a>

--- a/src/site/index.njk
+++ b/src/site/index.njk
@@ -17,6 +17,11 @@ eleventyComputed:
             <h3 class='ui-section-content__feed-date-heading'>{{ dateString }}</h3>
             <div class="ui-section-content--feature ui-layout-grid ui-layout-grid-3 ui-container-feed">
                 {% asyncEach feedItem in feedItems %}
+                    {% if loop.index <= 8 %}
+                        {% set imageLoading = 'eager' %}
+                    {% else %}
+                        {% set imageLoading = 'lazy' %}
+                    {% endif %}
                     {% include 'layouts/partials/feed-item.njk' %}
                 {% endeach %}
             </div>


### PR DESCRIPTION
- avif, jpegのみに。avifだけでも95%なのでwebpをサポートする意味があまりない。
- gtagはbodyの最後。スピード優先
- 最初の8記事だけloading=eagerに