### PR TITLE
fix(site): 画像のサイズを正しくレスポンシブに対応する

### DIFF
--- a/eleventy.config.ts
+++ b/eleventy.config.ts
@@ -40,7 +40,7 @@ const imageThumbnailShortcode = async (src: string, alt: string, pathPrefix = ''
 
   try {
     metadata = await EleventyImage(src, {
-      widths: [150, 450],
+      widths: [256, 512],
       formats: ['avif', 'jpeg'],
       outputDir: 'public/images/feed-thumbnails',
       urlPath: `${pathPrefix}images/feed-thumbnails/`,
@@ -61,7 +61,7 @@ const imageThumbnailShortcode = async (src: string, alt: string, pathPrefix = ''
 
   return EleventyImage.generateHTML(metadata, {
     alt,
-    sizes: '100vw',
+    sizes: '(min-width: 75rem) 16rem, (min-width: 64rem) 19rem, (min-width: 48rem) 19rem, 8rem',
     loading: imageLoading,
   });
 };

--- a/src/site/_includes/styles/main.css
+++ b/src/site/_includes/styles/main.css
@@ -213,7 +213,7 @@ img {
 .ui-feed-item {
   display: grid;
   color: var(--base-color);
-  grid-template-columns: 130px 1fr;
+  grid-template-columns: 8rem 1fr;
   align-content: start;
   grid-gap: 0 0.5em;
 }


### PR DESCRIPTION
sizesを適切に設定。

* デスクトップ向けは画像サイズが256px(16rem)で、retina向けに512px
* モバイル向けは128px(8rem)で、retina向けに256px
* タブレット向けは512px