### PR TITLE
add: 新規フィード追加

### DIFF
--- a/src/resources/feed-info-list.ts
+++ b/src/resources/feed-info-list.ts
@@ -36,6 +36,7 @@ export const FEED_INFO_LIST: FeedInfo[] = createFeedInfoList([
   ['AI inside', 'https://note.com/aiinside_tech/rss'],
   ['AIREV', 'https://zenn.dev/airev/feed'],
   ['ANDPAD', 'https://tech.andpad.co.jp/feed'],
+  ['Aokumo', 'https://aokumo.io/jp/rss.xml'],
   ['ARIGATOBANK', 'https://medium.com/feed/arigatobank-tech-blog'],
   ['ARMテックブログ', 'https://zenn.dev/p/arm_techblog/feed'],
   ['Acroquest Technology', 'https://acro-engineer.hatenablog.com/feed'],


### PR DESCRIPTION
## 概要
AokumoのテックブログのRSSフィードを追加いたします。

## 変更内容
- `src/resources/feed-info-list.ts` の `FEED_INFO_LIST` に以下を追加
- `['Aokumo', 'https://aokumo.io/jp/rss.xml']`

## 追加したフィード情報
- **ラベル**: Aokumo
- **URL**: https://aokumo.io/jp/rss.xml
- **説明**: Aokumoの技術ブログ

## 確認事項
- [x] アルファベット順に正しく挿入されています
- [x] URLが有効であることを確認済み
- [x] ラベルの重複がないことを確認済み

よろしくお願いいたします。