### PR TITLE
add: 新規フィード追加(ASSIGN)

### DIFF
--- a/src/resources/feed-info-list.ts
+++ b/src/resources/feed-info-list.ts
@@ -45,6 +45,7 @@ export const FEED_INFO_LIST: FeedInfo[] = createFeedInfoList([
   ['Algomatic', 'https://tech.algomatic.jp/feed'],
   ['AppBrew', 'https://tech.appbrew.io/feed'],
   ['AsiaQuest', 'https://techblog.asia-quest.jp/rss.xml'],
+  ['ASSIGN', 'https://zenn.dev/p/assign/feed'],
   ['Assured', 'https://tech.assured.jp/feed'],
   ['Axelspace', 'https://zenn.dev/p/axelspace/feed'],
   ['BABYJOB', 'https://zenn.dev/p/babyjob/feed'],


### PR DESCRIPTION
## 概要

[株式会社アサイン](https://assign-inc.com/)のテックブログのRSSフィードを追加いたします。

## 変更内容

`src/resources/feed-info-list.ts` の `FEED_INFO_LIST` に ASSIGNのzenn publicationのRSSフィードを追加しました。

## 確認事項

- [x] URLが有効であることを確認済み
- [x] ラベルの重複がないことを確認済み