### PR TITLE
chore(feed): PR TIMES 更新

### DIFF
--- a/src/resources/feed-info-list.ts
+++ b/src/resources/feed-info-list.ts
@@ -219,7 +219,7 @@ export const FEED_INFO_LIST: FeedInfo[] = createFeedInfoList([
   ['PLAID', 'https://tech.plaid.co.jp/rss.xml'],
   ['PLAY', 'https://developers.play.jp/feed'],
   ['POL', 'https://note.com/pollabbase/m/ma74382b91025/rss'],
-  ['PR TIMES', 'https://developers.prtimes.jp/feed/'],
+  ['PR TIMES', 'https://developers.prtimes.com/feed/'],
   // ['Pentagon', 'https://blog.pentagon.tokyo/category/engineering/feed/'],
   ['PharmaX', 'https://zenn.dev/p/pharmax/feed'],
   ['Playground', 'https://tech.playground.style/feed/'],


### PR DESCRIPTION
## 概要

- 企業名: PR TIMES
- ブログURL: https://developers.prtimes.com/
- RSSフィードURL: https://developers.prtimes.com/feed/

既存の PR TIMES フィードURLを現行ドメインの `developers.prtimes.com` に更新しました。

## 確認

- `https://developers.prtimes.com/feed/` が `200` / `application/rss+xml` で取得できることを確認
- `npm.cmd run test-internal` 通過

## 参考

- [月間7000万PV*の「PR TIMES」がサービスドメインを「prtimes.com」へ今秋移行 | 株式会社PR TIMESのプレスリリース](https://prtimes.jp/main/html/rd/p/000001644.000000112.html)