### PR TITLE
fix(feed): 不正なOG画像URLでGenerate Feedが失敗する問題を修正

### DIFF
--- a/src/feed/feed-generator.ts
+++ b/src/feed/feed-generator.ts
@@ -78,7 +78,7 @@ export class FeedGenerator {
 
       const ogObject = feedItemOgObjectMap.get(feedItem.link);
       const ogImage = ogObject?.customOgImage;
-      const feedItemImage = ogImage?.url && isValidHttpUrl(ogImage.url) ? ogImage : undefined;
+      const feedItemImage = ogImage?.url && isValidHttpUrl(ogImage.url) ? { ...ogImage } : undefined;
 
       if (feedItemImage?.alt) {
         feedItemImage.alt = escapeTextForXml(feedItemImage.alt);

--- a/src/feed/feed-generator.ts
+++ b/src/feed/feed-generator.ts
@@ -1,6 +1,6 @@
 import { Feed, type FeedOptions } from 'feed';
 import constants from '../common/constants.js';
-import { textToMd5Hash, textTruncate } from './common-util';
+import { isValidHttpUrl, textToMd5Hash, textTruncate } from './common-util';
 import type { CustomRssParserItem, FeedItemHatenaCountMap, OgObjectMap } from './feed-crawler';
 import { logger } from './logger';
 
@@ -78,9 +78,10 @@ export class FeedGenerator {
 
       const ogObject = feedItemOgObjectMap.get(feedItem.link);
       const ogImage = ogObject?.customOgImage;
+      const feedItemImage = ogImage?.url && isValidHttpUrl(ogImage.url) ? ogImage : undefined;
 
-      if (ogImage?.alt) {
-        ogImage.alt = escapeTextForXml(ogImage.alt);
+      if (feedItemImage?.alt) {
+        feedItemImage.alt = escapeTextForXml(feedItemImage.alt);
       }
 
       // 日付がないものは入れない
@@ -110,7 +111,7 @@ export class FeedGenerator {
                 },
               ]
             : undefined,
-        image: ogImage?.url ? ogImage : undefined,
+        image: feedItemImage,
         published: new Date(feedItem.isoDate),
         date: new Date(feedItem.isoDate),
         extensions: [

--- a/tests/feed-generator.test.ts
+++ b/tests/feed-generator.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import type { CustomRssParserItem, OgObjectMap } from '../src/feed/feed-crawler';
+import { FeedGenerator } from '../src/feed/feed-generator';
+
+describe('FeedGenerator', () => {
+  it('不正なOG画像URLは画像なしとしてフィード生成できる', () => {
+    const feedItem = {
+      title: 'テスト記事',
+      link: 'https://example.com/test-article/',
+      guid: 'https://example.com/?p=1',
+      isoDate: '2026-06-09T04:03:10.000Z',
+      blogTitle: 'Example Tech Blog',
+      blogLink: 'https://example.com',
+    } as CustomRssParserItem;
+    const ogObjectMap = new Map([
+      [
+        feedItem.link,
+        {
+          // ホスト名に %20 を含むURLは new URL() が throw する
+          customOgImage: {
+            url: 'http://Invalid%20Og%20Image',
+          },
+        },
+      ],
+    ]) as OgObjectMap;
+    const feedGenerator = new FeedGenerator();
+
+    const result = feedGenerator.generateFeeds([feedItem], ogObjectMap, new Map(), 200, 500);
+
+    expect(result.aggregatedFeed.items[0].image).toBeUndefined();
+    expect(result.feedDistributionSet.atom).toContain('<feed');
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "target": "es2021",
     "module": "esnext",
     "moduleResolution": "node",
+    "ignoreDeprecations": "6.0",
     "esModuleInterop": true,
     "lib": ["dom", "esnext"],
     "types": ["node", "vitest/globals", "open-graph-scraper"],


### PR DESCRIPTION
いつも企業テックブログRSSを購読・活用させていただいています。
便利なフィードを公開・運用いただきありがとうございます。

6/8以降フィード生成が失敗しているようでしたので、下記の変更を行いました。
おてすきの際にご確認いただけますと幸いです。

## 概要
<!--
どのような変更をしたか簡潔に記載してください

新規フィード追加の場合、以下が含まれていると確認が捗ります
- 企業名
- ブログURL
- RSSフィードURL
-->

fixes: #320 

og:imageに`http://Deep%20Instinct`のような不正なURLが含まれると、 feedライブラリの`atom1()`内の`new URL()`が TypeError: Invalid URLをthrowすることで、フィード生成全体が失敗してしまっています。
URLとして不正なOG画像はスキップし、フィード生成全体が落ちないように変更を行いました。

併せてTypeScript v6で `moduleResolution: node (node10)` が エラー化したため、`ignoreDeprecations`を追加しています。