### PR TITLE
chore(ci): harden workflow permissions and dependency hygiene

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -10,6 +10,8 @@
   "dependencyDashboard": false,
   "labels": ["dependencies", "renovate"],
   "automerge": true,
+  // 公開直後のパッケージは 3 日間の様子見期間を設けてから automerge する
+  "minimumReleaseAge": '3 days',
   "packageRules": [
     {
       matchDepTypes: ['peerDependencies'],

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   lint-biome:
     name: Lint Biome

--- a/.github/workflows/generate-feed.yml
+++ b/.github/workflows/generate-feed.yml
@@ -12,11 +12,20 @@ on:
     - cron: 0 23,1,3,5,7,9,11,13,15 * * 0,6
   workflow_dispatch:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: generate-feed
+  cancel-in-progress: true
+
 jobs:
   generate-feed:
     name: Generate Feed
     runs-on: ubuntu-24.04
     timeout-minutes: 30
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v7
         with:

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ GitHub Actions で定期的に更新されており、サイトの生成は [Ele
 ### フォークして使う場合
 以下を書き換えると独自のサイトが動きます。
 
-- `src/common/constants.js` の URL など
+- `src/common/constants.ts` の URL など
 - `src/resources/feed-info-list.ts` のブログ情報
 
 特定のブログに絞ったり、以下のように全く違ったフィードを作るもの良いと思います。
@@ -70,7 +70,7 @@ GitHub Actions で定期的に更新されており、サイトの生成は [Ele
 
 ### 開発環境とコマンド
 環境
-- Node.js >= 20
+- Node.js >= 24
 
 パッケージのインストール
 ```bash
@@ -88,7 +88,7 @@ $ npm run site-serve
 
 コードのチェック
 ```bash
-$ # eslint, tsc --noEmit
+$ # Biome, tsc --noEmit, secretlint
 $ npm run lint
 
 $ # テスト

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,14 +17,11 @@
         "@secretlint/secretlint-rule-preset-recommend": "^13.0.2",
         "@supercharge/promise-pool": "^3.3.0",
         "@types/11ty__eleventy-img": "^4.0.0",
-        "@types/async-retry": "^1.4.9",
         "@types/clean-css": "^4.2.11",
         "@types/html-minifier-terser": "^7.0.2",
-        "@types/http-server": "^0.12.4",
         "@types/node": "^24.13.2",
         "@types/open-graph-scraper": "^5.2.3",
         "@vitest/coverage-v8": "^4.1.9",
-        "async-retry": "^1.3.3",
         "await-to-js": "^3.0.0",
         "axios": "^1.18.1",
         "clean-css": "^5.3.3",
@@ -34,7 +31,6 @@
         "flat-cache": "^6.1.23",
         "googleapis": "^173.0.0",
         "html-minifier-terser": "^7.2.0",
-        "http-server": "^14.1.1",
         "log4js": "^6.9.1",
         "open-graph-scraper": "^6.12.0",
         "rss-parser": "^3.13.0",
@@ -45,7 +41,7 @@
         "vitest": "^4.1.9"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=24"
       }
     },
     "node_modules/@11ty/dependency-tree": {
@@ -2452,16 +2448,6 @@
         "@types/sharp": "^0.31.0"
       }
     },
-    "node_modules/@types/async-retry": {
-      "version": "1.4.9",
-      "resolved": "https://registry.npmjs.org/@types/async-retry/-/async-retry-1.4.9.tgz",
-      "integrity": "sha512-s1ciZQJzRh3708X/m3vPExr5KJlzlZJvXsKpbtE2luqNcbROr64qU+3KpJsYHqWMeaxI839OvXf9PrUSw1Xtyg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/retry": "*"
-      }
-    },
     "node_modules/@types/chai": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
@@ -2481,16 +2467,6 @@
       "dependencies": {
         "@types/node": "*",
         "source-map": "^0.6.0"
-      }
-    },
-    "node_modules/@types/connect": {
-      "version": "3.4.38",
-      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
-      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "node_modules/@types/deep-eql": {
@@ -2513,16 +2489,6 @@
       "integrity": "sha512-mm2HqV22l8lFQh4r2oSsOEVea+m0qqxEmwpc9kC1p/XzmjLWrReR9D/GRs8Pex2NX/imyEH9c5IU/7tMBQCHOA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/http-server": {
-      "version": "0.12.4",
-      "resolved": "https://registry.npmjs.org/@types/http-server/-/http-server-0.12.4.tgz",
-      "integrity": "sha512-vsn4pvP2oRFALLuM5Rca6qUmSPG7u0VNjOuqvL57l3bKldQRWdUZPeSiARhzagDxgfNCHn/o8WlWk4KinBauUg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/connect": "*"
-      }
     },
     "node_modules/@types/node": {
       "version": "24.13.2",
@@ -2551,13 +2517,6 @@
       "dependencies": {
         "open-graph-scraper": "*"
       }
-    },
-    "node_modules/@types/retry": {
-      "version": "0.12.5",
-      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.5.tgz",
-      "integrity": "sha512-3xSjTp3v03X/lSQLkczaN9UIEwJMoMCA1+Nb5HfbJEQWogdeQIyVtTvxPXDQjZ5zws8rFQfVfRdz03ARihPJgw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/sharp": {
       "version": "0.31.1",
@@ -2885,26 +2844,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/async": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
-      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lodash": "^4.17.14"
-      }
-    },
-    "node_modules/async-retry": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
-      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "retry": "0.13.1"
-      }
-    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -2988,26 +2927,6 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT"
-    },
-    "node_modules/basic-auth": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
-      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "5.1.2"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/basic-auth/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/bcp-47": {
@@ -3409,16 +3328,6 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/corser": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/corser/-/corser-2.0.1.tgz",
-      "integrity": "sha512-utCYNzRSQIZNPIcGZdQc92UVJYAhtGAteCFg0yRaFm8f0P+CPtyGyHXJcGXnffjCybUCEx3FQ2G7U3/o9eIkVQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4.0"
-      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -4675,16 +4584,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/he": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "he": "bin/he"
-      }
-    },
     "node_modules/hookified": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.15.0.tgz",
@@ -4713,19 +4612,6 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
-      }
-    },
-    "node_modules/html-encoding-sniffer": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
-      "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-encoding": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/html-escaper": {
@@ -4828,62 +4714,6 @@
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/http-proxy": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
-      "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "eventemitter3": "^4.0.0",
-        "follow-redirects": "^1.0.0",
-        "requires-port": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/http-server": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/http-server/-/http-server-14.1.1.tgz",
-      "integrity": "sha512-+cbxadF40UXd9T01zUHgA+rlo2Bg1Srer4+B4NwIHdaGxAGGv59nYRnGGDJ9LBk7alpS0US+J+bLLdQOOkJq4A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "basic-auth": "^2.0.1",
-        "chalk": "^4.1.2",
-        "corser": "^2.0.1",
-        "he": "^1.2.0",
-        "html-encoding-sniffer": "^3.0.0",
-        "http-proxy": "^1.18.1",
-        "mime": "^1.6.0",
-        "minimist": "^1.2.6",
-        "opener": "^1.5.1",
-        "portfinder": "^1.0.28",
-        "secure-compare": "3.0.1",
-        "union": "~0.5.0",
-        "url-join": "^4.0.1"
-      },
-      "bin": {
-        "http-server": "bin/http-server"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/http-server/node_modules/mime": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "mime": "cli.js"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/https-proxy-agent": {
@@ -6102,16 +5932,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/opener": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
-      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
-      "dev": true,
-      "license": "(WTFPL OR MIT)",
-      "bin": {
-        "opener": "bin/opener-bin.js"
-      }
-    },
     "node_modules/p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
@@ -6380,44 +6200,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/portfinder": {
-      "version": "1.0.32",
-      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.32.tgz",
-      "integrity": "sha512-on2ZJVVDXRADWE6jnQaX0ioEylzgBpQk8r55NE4wjXW1ZxO+BgDlY6DXwj20i0V8eB4SenDQ00WEaxfiIQPcxg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "async": "^2.6.4",
-        "debug": "^3.2.7",
-        "mkdirp": "^0.5.6"
-      },
-      "engines": {
-        "node": ">= 0.12.0"
-      }
-    },
-    "node_modules/portfinder/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
-    "node_modules/portfinder/node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
       }
     },
     "node_modules/postcss": {
@@ -6769,23 +6551,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/requires-port": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/retry": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
-      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
     "node_modules/rfdc": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
@@ -6935,13 +6700,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/secure-compare": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/secure-compare/-/secure-compare-3.0.1.tgz",
-      "integrity": "sha512-AckIIV90rPDcBcglUwXPF3kg0P0qmPsPXAj6BBEENQE1p5yA1xfmDJzfi1Tappj37Pv2mVbKpL3Z1T+Nn7k1Qw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.8.5",
@@ -7838,18 +7596,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/union": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/union/-/union-0.5.0.tgz",
-      "integrity": "sha512-N6uOhuW6zO95P3Mel2I2zMsbsanvvtgn6jVqJv4vbVcz/JN0OkL9suomjQGmWtxJQXOCqUJvquc1sMeNz/IwlA==",
-      "dev": true,
-      "dependencies": {
-        "qs": "^6.4.0"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -7859,13 +7605,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/url-join": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
-      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/url-template": {
       "version": "2.0.8",
@@ -8115,19 +7854,6 @@
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "dev": true,
       "license": "BSD-2-Clause"
-    },
-    "node_modules/whatwg-encoding": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
-      "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "iconv-lite": "0.6.3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
     },
     "node_modules/whatwg-mimetype": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -48,14 +48,11 @@
     "@secretlint/secretlint-rule-preset-recommend": "^13.0.2",
     "@supercharge/promise-pool": "^3.3.0",
     "@types/11ty__eleventy-img": "^4.0.0",
-    "@types/async-retry": "^1.4.9",
     "@types/clean-css": "^4.2.11",
     "@types/html-minifier-terser": "^7.0.2",
-    "@types/http-server": "^0.12.4",
     "@types/node": "^24.13.2",
     "@types/open-graph-scraper": "^5.2.3",
     "@vitest/coverage-v8": "^4.1.9",
-    "async-retry": "^1.3.3",
     "await-to-js": "^3.0.0",
     "axios": "^1.18.1",
     "clean-css": "^5.3.3",
@@ -65,7 +62,6 @@
     "flat-cache": "^6.1.23",
     "googleapis": "^173.0.0",
     "html-minifier-terser": "^7.2.0",
-    "http-server": "^14.1.1",
     "log4js": "^6.9.1",
     "open-graph-scraper": "^6.12.0",
     "rss-parser": "^3.13.0",
@@ -76,6 +72,6 @@
     "vitest": "^4.1.9"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=24"
   }
 }


### PR DESCRIPTION
## 概要

Hardens CI/CD configuration and cleans up dependency hygiene:

- **Workflow permissions**: Add `permissions: contents: read` at top level of `ci.yml` and `generate-feed.yml` (the repo default token permission is write; no CI job needs it). The gh-pages deploy job gets `contents: write` scoped at job level only.
- **Concurrency guard**: `generate-feed.yml` is triggered by 26 cron entries + push + manual dispatch, and ends with a force-push to `gh-pages`. Overlapping runs could race; a `concurrency` group with `cancel-in-progress` prevents that.
- **Renovate soak period**: Add `minimumReleaseAge: '3 days'` so freshly-published packages are not automerged immediately (supply-chain risk mitigation).
- **Remove unused devDependencies**: `http-server`, `@types/http-server`, `async-retry`, `@types/async-retry` are unreferenced anywhere in the codebase (`site-serve` uses Eleventy's `--serve`). 24 packages removed from the lockfile.
- **engines.node**: `>=20` → `>=24` to match what CI actually tests (`.tool-versions` pins 24.0.1, all jobs use `node-version-file`).
- **README**: Fix stale references (`constants.js` → `constants.ts`, eslint → Biome/tsc/secretlint, Node.js >= 24).

## 確認

- `npm run lint` (Biome + tsc + secretlint): pass
- `npm run test-internal`: 12/12 pass
- Both workflow files YAML-parsed, renovate.json5 JSON5-parsed

🤖 Generated with [Claude Code](https://claude.com/claude-code)