### PR TITLE
fix(feed): handle hatena count fetch errors and add fetch timeout

### DIFF
--- a/src/feed/feed-crawler.ts
+++ b/src/feed/feed-crawler.ts
@@ -124,7 +124,9 @@ export class FeedCrawler {
               logger.trace('[fetch-feed] cache hit', feedInfo.label, feedInfo.url);
               feedData = cachedData;
             } else {
-              const response = await fetch(feedInfo.url);
+              const response = await fetch(feedInfo.url, {
+                signal: AbortSignal.timeout(1000 * 10),
+              });
               if (!response.ok) {
                 throw new Error(`HTTP Error: ${response.status}`);
               }
@@ -484,7 +486,9 @@ export class FeedCrawler {
       const [error, hatenaCountMap] = await to(fetchHatenaCountMap(feedItemUrls));
 
       if (error) {
-        Promise.reject(new Error('[hatena-count] Fail to get hatena bookmark count', { cause: error }));
+        logger.error('[fetch-feed-item-hatena-count] error');
+        logger.trace(error);
+        continue;
       }
 
       for (const feedItemUrl in hatenaCountMap) {


### PR DESCRIPTION
## 概要

Two robustness fixes in the feed crawler:

- **Fix a bare `Promise.reject` statement** in the hatena bookmark count loop (`feed-crawler.ts:487`). It created an unhandled promise rejection on fetch failure — which can crash the Node process — instead of handling the error. Since hatena counts are non-critical enrichment data, the error is now logged (matching the file's existing non-fatal fetch-error pattern) and the loop explicitly `continue`s to the next chunk.
- **Add a timeout to the feed XML `fetch`** (`feed-crawler.ts:127`), which previously had no timeout and could hang the crawl on an unresponsive feed. Uses `AbortSignal.timeout(1000 * 10)`, consistent with the other 10s timeouts in this file.

Note: the `RssParser` constructor's `timeout`/`maxRedirects` options only apply to `parseURL`, which this code never calls (it fetches XML itself and uses `parseString`) — so the actual network path needed its own timeout.

## 確認

- `npm run lint`: pass
- `npm run test-internal`: 12/12 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)