### PR TITLE
fix(site): add rel=noopener to external links and canonical URLs

### DIFF
--- a/src/site/_includes/components/top-section.ts
+++ b/src/site/_includes/components/top-section.ts
@@ -33,10 +33,10 @@ export const renderTopSection = (page: EleventyPage): string => {
                     <button type="button" class="ui-component-button ui-component-button-medium ui-component-button-primary feed-url-copy-button">コピー</button>
                 </form>
                 <div class='ui-top-section__subscribe'>
-                    <a href='https://feedly.com/i/subscription/feed/${rssFeedUrl}' target="_blank">
+                    <a href='https://feedly.com/i/subscription/feed/${rssFeedUrl}' target="_blank" rel="noopener noreferrer">
                         <img src='${relativeUrl}images/subscribe-feedly.png' loading="eager" alt='follow us in feedly' width='152' height='56'>
                     </a>
-                    <a href="https://www.inoreader.com?add_feed=${rssFeedUrl}" target="_blank">
+                    <a href="https://www.inoreader.com?add_feed=${rssFeedUrl}" target="_blank" rel="noopener noreferrer">
                         <img src="${relativeUrl}images/subscribe-inoreader.png" loading="eager" alt="follow us in inoreader" width='260' height='72'>
                     </a>
                 </div>

--- a/src/site/_includes/layouts/main.11ty.ts
+++ b/src/site/_includes/layouts/main.11ty.ts
@@ -16,6 +16,7 @@ export function render(data: MainLayoutData): string {
   const { content, pageTitle, page } = data;
   const relativeUrl = escapeHtml(relativeUrlFilter(page.url));
   const escapedPageTitle = escapeHtml(pageTitle);
+  const canonicalUrl = escapeHtml(`${constants.siteUrl}${page.url.replace(/^\//, '')}`);
 
   const prerender = ['/'].includes(page.url) ? `<link rel="prerender" href="${relativeUrl}hot/">` : '';
 
@@ -42,7 +43,7 @@ export function render(data: MainLayoutData): string {
   const howToAddSite = constants.howToAddSiteLink
     ? `<p class='ui-text-note'>
                         追加したいブログがある場合は<br>
-                        <a href='${escapeHtml(constants.howToAddSiteLink)}' target="_blank">サイトの追加方法</a>
+                        <a href='${escapeHtml(constants.howToAddSiteLink)}' target="_blank" rel="noopener noreferrer">サイトの追加方法</a>
                         をご参照ください。
                     </p>`
     : '';
@@ -73,6 +74,7 @@ export function render(data: MainLayoutData): string {
 
     <meta name="thumbnail" content="${escapeHtml(constants.siteUrl)}images/og-image.png" />
 
+    <link rel="canonical" href="${canonicalUrl}">
     <link rel="preload" href="${relativeUrl}styles/bundle.css" as="style">
     ${prerender}
 
@@ -100,10 +102,10 @@ export function render(data: MainLayoutData): string {
                     <span class='ui-section-header__title'>${escapeHtml(constants.siteTitle)}</span>
                 </a>
                 <div class="ui-section-header__links">
-                    <a href="${escapeHtml(constants.gitHubRepositoryUrl)}" role="link" aria-label="GitHub" target="_blank">
+                    <a href="${escapeHtml(constants.gitHubRepositoryUrl)}" role="link" aria-label="GitHub" target="_blank" rel="noopener noreferrer">
                         <img src='${relativeUrl}images/icon-github.png' alt='GitHubロゴ' loading="eager" width='96' height='96' />
                     </a>
-                    <a href="${escapeHtml(constants.xUserUrl)}" role="link" aria-label="X" target="_blank">
+                    <a href="${escapeHtml(constants.xUserUrl)}" role="link" aria-label="X" target="_blank" rel="noopener noreferrer">
                         <img src='${relativeUrl}images/icon-x.png' alt='Xロゴ' loading="eager" width='96' height='96' />
                     </a>
                 </div>
@@ -129,9 +131,9 @@ export function render(data: MainLayoutData): string {
         <div class="ui-layout-container">
             <div class="ui-section-footer__layout ui-layout-flex">
                 <p class="ui-section-footer--copyright ui-text-note">
-                    <a class="ui-text-note" href='${escapeHtml(constants.gitHubUserUrl)}' target="_blank"><small>@${escapeHtml(constants.author)}</small></a>
+                    <a class="ui-text-note" href='${escapeHtml(constants.gitHubUserUrl)}' target="_blank" rel="noopener noreferrer"><small>@${escapeHtml(constants.author)}</small></a>
                 </p>
-                <a href="${escapeHtml(constants.gitHubRepositoryUrl)}" role="link" class="ui-text-note" target="_blank"><small>GitHub</small></a>
+                <a href="${escapeHtml(constants.gitHubRepositoryUrl)}" role="link" class="ui-text-note" target="_blank" rel="noopener noreferrer"><small>GitHub</small></a>
             </div>
         </div>
     </footer>

--- a/src/site/_includes/layouts/main.11ty.ts
+++ b/src/site/_includes/layouts/main.11ty.ts
@@ -16,7 +16,7 @@ export function render(data: MainLayoutData): string {
   const { content, pageTitle, page } = data;
   const relativeUrl = escapeHtml(relativeUrlFilter(page.url));
   const escapedPageTitle = escapeHtml(pageTitle);
-  const canonicalUrl = escapeHtml(`${constants.siteUrl}${page.url.replace(/^\//, '')}`);
+  const canonicalUrl = escapeHtml(`${constants.siteUrlStem}${page.url}`);
 
   const prerender = ['/'].includes(page.url) ? `<link rel="prerender" href="${relativeUrl}hot/">` : '';
 

--- a/src/site/site.11ty.ts
+++ b/src/site/site.11ty.ts
@@ -1,3 +1,5 @@
+// /site.xml を生成する。/sitemap.xml を生成する sitemap.11ty.ts と同一内容のため、
+// どちらか一方を変更する場合は両方を同期させること。
 import { type SitemapData, renderSitemap } from './_includes/components/sitemap';
 
 export const data = {

--- a/src/site/sitemap.11ty.ts
+++ b/src/site/sitemap.11ty.ts
@@ -1,3 +1,5 @@
+// /sitemap.xml を生成する。/site.xml を生成する site.11ty.ts と同一内容のため、
+// どちらか一方を変更する場合は両方を同期させること。
 import { type SitemapData, renderSitemap } from './_includes/components/sitemap';
 
 export const data = {


### PR DESCRIPTION
## 概要

Small link-security / SEO improvements to the generated site:

- **`rel="noopener noreferrer"` on all `target="_blank"` anchors** (7 total: header GitHub/X, footer author/GitHub, サイトの追加方法 link, Feedly/Inoreader subscribe buttons) — prevents reverse-tabnabbing via `window.opener`.
- **`<link rel="canonical">` in the layout `<head>`** with the absolute per-page URL (e.g. `.../tech-blog-rss-feed/`, `.../hot/`, `.../blogs/<hash>/`) — previously no canonical was emitted at all.
- **Cross-reference comments** on `site.11ty.ts` / `sitemap.11ty.ts`, which are intentionally identical templates producing `/site.xml` and `/sitemap.xml`, so future edits don't land in only one. (Neither file removed — external consumers of `/site.xml` are unknown.)

## 確認

- `npm run lint` / `npm run test-internal` (12/12): pass
- Full build diff against `main` baseline (627 files): only the intended changes — canonical `<link>` on 624 pages, `rel="noopener noreferrer"` on 624 pages, plus 6 files with dayjs relative-time drift. `site.xml` / `sitemap.xml` byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)