### PR TITLE
feat(site): recompute relative dates on the client

### DIFF
--- a/src/site/_includes/components/feed-item.ts
+++ b/src/site/_includes/components/feed-item.ts
@@ -34,6 +34,10 @@ export const renderFeedItem = async (
     ? `<div class='ui-feed-item__summary'>${escapeHtml(truncateNunjucks(feedItem.content_html, 500))}</div>`
     : '';
 
+  // data-datetime lets scripts/relative-time.ts recompute the relative date on the client;
+  // the build-time diffDateForHuman text remains as a no-JS fallback.
+  const dateAttr = feedItem.date_published ? ` data-datetime='${escapeHtml(feedItem.date_published)}'` : '';
+
   return `<div class='ui-feed-item'>
     <a class='ui-feed-item__og-image' href='${escapeHtml(feedItem.url)}'>
         ${ogImage}
@@ -46,7 +50,7 @@ export const renderFeedItem = async (
           <span>${escapeHtml(feedItem._custom.blogTitle)}</span>
         </a>
         ${summary}
-        <div class='ui-feed-item__date' title='${escapeHtml(feedItem.pubDateForHuman)}'>${escapeHtml(feedItem.diffDateForHuman)}</div>
+        <div class='ui-feed-item__date'${dateAttr} title='${escapeHtml(feedItem.pubDateForHuman)}'>${escapeHtml(feedItem.diffDateForHuman)}</div>
     </div>
 </div>`;
 };

--- a/src/site/_includes/components/scripts.ts
+++ b/src/site/_includes/components/scripts.ts
@@ -6,3 +6,13 @@ import { fileURLToPath } from 'node:url';
  * Nunjucks の `{% include "scripts/index.ts" %}` 相当（ファイル内容をそのまま埋め込む）。
  */
 export const indexScript = fs.readFileSync(fileURLToPath(new URL('../scripts/index.ts', import.meta.url)), 'utf-8');
+
+/**
+ * Client script that recomputes relative dates ("◯分前") against the viewer's
+ * current time. Included by the shared layout (layouts/main.11ty.ts) so it
+ * applies to every page.
+ */
+export const relativeTimeScript = fs.readFileSync(
+  fileURLToPath(new URL('../scripts/relative-time.ts', import.meta.url)),
+  'utf-8',
+);

--- a/src/site/_includes/layouts/main.11ty.ts
+++ b/src/site/_includes/layouts/main.11ty.ts
@@ -1,6 +1,7 @@
 import constants from '../../../common/constants';
 import { relativeUrlFilter } from '../../../common/eleventy-utils';
 import { escapeHtml } from '../components/html-utils';
+import { relativeTimeScript } from '../components/scripts';
 import type { EleventyPage } from '../components/types';
 
 interface MainLayoutData {
@@ -137,6 +138,10 @@ export function render(data: MainLayoutData): string {
             </div>
         </div>
     </footer>
+
+    <script>
+    ${relativeTimeScript}
+    </script>
 
 </body>
 </html>`;

--- a/src/site/_includes/scripts/relative-time.ts
+++ b/src/site/_includes/scripts/relative-time.ts
@@ -1,0 +1,39 @@
+// Recompute "○分前" style relative dates against the viewer's current time.
+// The build embeds a relative date computed at build time (the site rebuilds
+// only hourly, so it drifts); elements carrying a `data-datetime` ISO date get
+// their text replaced on load. Without JS the build-time text remains as-is.
+// Thresholds and wording mirror dayjs's relativeTime plugin with the ja locale
+// so that the replaced text matches the build-time output.
+// NOTE: this file is inlined into <script> as-is (see components/scripts.ts),
+// so it must stay plain JS — no TypeScript-only syntax (the `= 0` default is
+// how the parameter gets its type without an annotation).
+const formatRelativeTime = (diffMs = 0) => {
+  const sec = Math.max(0, diffMs) / 1000;
+  if (sec < 45) {
+    return '数秒前';
+  }
+  const min = Math.round(sec / 60);
+  if (min < 45) {
+    return `${Math.max(1, min)}分前`;
+  }
+  const hour = Math.round(sec / 3600);
+  if (hour < 22) {
+    return `${Math.max(1, hour)}時間前`;
+  }
+  const day = Math.round(sec / 86400);
+  if (day < 26) {
+    return `${Math.max(1, day)}日前`;
+  }
+  const month = Math.round(day / 30.44);
+  if (month < 11) {
+    return `${Math.max(1, month)}ヶ月前`;
+  }
+  return `${Math.max(1, Math.round(month / 12))}年前`;
+};
+
+for (const elem of document.querySelectorAll('[data-datetime]')) {
+  const parsed = Date.parse(elem.getAttribute('data-datetime') ?? '');
+  if (!Number.isNaN(parsed)) {
+    elem.textContent = formatRelativeTime(Date.now() - parsed);
+  }
+}

--- a/src/site/blog-feed.11ty.ts
+++ b/src/site/blog-feed.11ty.ts
@@ -53,6 +53,10 @@ export async function render(data: BlogFeedData): Promise<string> {
         ? `<div class='ui-feed-item__summary'>${escapeHtml(truncateNunjucks(feedItem.content_html, 1000))}</div>`
         : '';
 
+      // data-datetime lets scripts/relative-time.ts recompute the relative date on the client;
+      // the build-time diffDateForHuman text remains as a no-JS fallback.
+      const dateAttr = feedItem.isoDate ? ` data-datetime='${escapeHtml(feedItem.isoDate)}'` : '';
+
       return `<div class='ui-feed-item'>
                     <a class='ui-feed-item__og-image' href='${escapeHtml(feedItem.link)}'>
                         ${ogImage}
@@ -62,7 +66,7 @@ export async function render(data: BlogFeedData): Promise<string> {
                         ${hatenaCount}
                         <div class='ui-feed-item__blog-title'>${escapeHtml(blogTitle)}</div>
                         ${summary}
-                        <div class='ui-feed-item__date' title='${escapeHtml(feedItem.pubDateForHuman)}'>${escapeHtml(feedItem.diffDateForHuman)}</div>
+                        <div class='ui-feed-item__date'${dateAttr} title='${escapeHtml(feedItem.pubDateForHuman)}'>${escapeHtml(feedItem.diffDateForHuman)}</div>
                     </div>
                 </div>`;
     }),

--- a/src/site/blogs.11ty.ts
+++ b/src/site/blogs.11ty.ts
@@ -33,8 +33,10 @@ export async function render(data: BlogsData): Promise<string> {
         ? `<div class='ui-blog__description'>${escapeHtml(truncateNunjucks(blogFeed.ogDescription, 200))}</div>`
         : '';
 
+      // data-datetime lets scripts/relative-time.ts recompute the relative date on the client;
+      // the build-time diffLastUpdatedDateForHuman text remains as a no-JS fallback.
       const date = blogFeed.lastUpdated
-        ? `<div class='ui-blog__date' title='${escapeHtml(blogFeed.lastUpdatedForHuman)}'>${escapeHtml(blogFeed.diffLastUpdatedDateForHuman)}</div>`
+        ? `<div class='ui-blog__date' data-datetime='${escapeHtml(blogFeed.lastUpdatedIso)}' title='${escapeHtml(blogFeed.lastUpdatedForHuman)}'>${escapeHtml(blogFeed.diffLastUpdatedDateForHuman)}</div>`
         : `<div class='ui-blog__date' title='更新日時なし'>-</div>`;
 
       return `<div class='ui-blog'>


### PR DESCRIPTION
## 概要

Recompute the "N分前" relative-date labels against the viewer's current time instead of showing the build-time value.

### Why

The labels are computed with dayjs at build time and baked into the static HTML. Since the site rebuilds only every 1–2 hours, a label like "38分前" can be stale by up to the rebuild interval by the time someone views the page.

### How

- Each date element now carries the ISO published date in a `data-datetime` attribute (top/hot feed items, per-blog feed pages, and the blog list's last-updated label).
- A small inline script (`src/site/_includes/scripts/relative-time.ts`, included from the shared layout) rewrites the label on load using the viewer's clock.
- The formatter mirrors dayjs's relativeTime thresholds and ja locale wording — verified to match `now.to(...)` output across all threshold boundaries (数秒前/分/時間/日/ヶ月/年).
- The build-time label remains as a no-JS fallback; the absolute-time `title` attribute is unchanged.

### Verification

- `npm run lint` and `npm run test-internal` pass.
- Built the site locally from cached feed data and confirmed `data-datetime` renders on all four page types and the inline script executes as plain JS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)