### PR TITLE
perf(feed): prune stale caches and reduce fetch retries

### DIFF
--- a/.github/workflows/generate-feed.yml
+++ b/.github/workflows/generate-feed.yml
@@ -36,6 +36,7 @@ jobs:
           cache: npm
       - run: npm ci
       - uses: ./.github/actions/restore-feed-cache
+      - run: npm run cache-prune
       - run: npm run feed-generate
       - run: npm run site-prepare
       - run: npm run site-build

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "npm run feed-generate && npm run site-build",
     "feed-generate": "tsx src/cli/generate-feed-command.ts",
+    "cache-prune": "tsx src/cli/prune-cache-command.ts",
     "register-index": "tsx src/cli/register-index-command.ts",
     "site-prepare": "tsx src/cli/prepare-site-command.ts",
     "site-build": "tsx ./node_modules/.bin/eleventy --config=eleventy.config.ts",

--- a/src/cli/generate-feed-command.ts
+++ b/src/cli/generate-feed-command.ts
@@ -27,6 +27,9 @@ const feedStorer = new FeedStorer();
     new Date(Date.now() - constants.aggregateFeedDurationInHours * 60 * 60 * 1000),
   );
 
+  // まとめフィード作成 + ファイル出力 + バリデーション
+  const generateStoreValidateStartTime = Date.now();
+
   // まとめフィード作成
   const ogObjectMap = new Map([...crawlFeedsResult.feedItemOgObjectMap, ...crawlFeedsResult.feedBlogOgObjectMap]);
   const generateFeedsResult = feedGenerator.generateFeeds(
@@ -71,4 +74,9 @@ const feedStorer = new FeedStorer();
     console.error(error);
     throw error;
   }
+
+  logger.info(
+    '[phase] generate + store + validate feeds',
+    `${((Date.now() - generateStoreValidateStartTime) / 1000).toFixed(1)}s`,
+  );
 })();

--- a/src/cli/prune-cache-command.ts
+++ b/src/cli/prune-cache-command.ts
@@ -1,0 +1,45 @@
+import * as path from 'node:path';
+import * as url from 'node:url';
+import constants from '../common/constants';
+import { logger } from '../feed/logger';
+import { pruneCache } from '../feed/prune-cache';
+
+const dirName = url.fileURLToPath(new URL('.', import.meta.url));
+const REPO_ROOT_DIR_PATH = path.join(dirName, '../..');
+
+// プルーニング対象のディレクトリ
+// - .cache: flat-cache（フィード・OGPキャッシュ）と eleventy-fetch（画像バッファ）が使う
+// - public/images/feed-thumbnails, public/images/feed-icons: eleventy-img が生成するサムネイル・アイコン
+//
+// フィードキャッシュは1時間、OGPキャッシュは記事が集計対象期間(8日間)に入っている間24時間おき、
+// eleventy-fetchのバッファは3日おきに書き換わって mtime が更新されるため、
+// mtime が constants.cachePruneThresholdInDays より古いファイルは実質使われなくなったキャッシュとみなせる。
+// 生成画像(feed-thumbnails/feed-icons)は古い mtime のまま参照され続ける可能性があるが、
+// このコマンドは CI 上で site-prepare / site-build より前に実行するため、
+// まだ必要な画像は同じ実行内で再生成される（自己修復的なので消しすぎを心配しなくてよい）。
+const TARGET_DIRS = [
+  path.join(REPO_ROOT_DIR_PATH, '.cache'),
+  path.join(REPO_ROOT_DIR_PATH, 'public/images/feed-thumbnails'),
+  path.join(REPO_ROOT_DIR_PATH, 'public/images/feed-icons'),
+];
+
+(async () => {
+  logger.info('[prune-cache] start', TARGET_DIRS);
+
+  const result = await pruneCache(TARGET_DIRS, constants.cachePruneThresholdInDays);
+
+  for (const dirResult of result.dirResults) {
+    logger.info(
+      '[prune-cache] pruned',
+      dirResult.dir,
+      `${dirResult.deletedFileCount} files deleted`,
+      `${(dirResult.freedBytes / 1024 / 1024).toFixed(2)} MB freed`,
+    );
+  }
+
+  logger.info(
+    '[prune-cache] finished',
+    `${result.totalDeletedFileCount} files deleted`,
+    `${(result.totalFreedBytes / 1024 / 1024).toFixed(2)} MB freed in total`,
+  );
+})();

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -48,4 +48,8 @@ export default {
   eleventyFetchConcurrency: 50, // Eleventyの画像取得の並列数
   fetchedFeedCacheDurationInHours: 1, // フィードのキャッシュの有効時間
   fetchedOgCacheDurationInHours: 24, // OG情報のキャッシュの有効時間
+  cachePruneThresholdInDays: 14, // キャッシュ削除の閾値。フィードは1時間、OGPは記事が集計対象期間(8日間)に入っている間24時間おき、
+  // eleventy-fetchのバッファは3日おきに更新されるため、14日以上古いファイルは実質使われていないとみなせる
+  feedFetchRetryCount: 1, // フィード取得のリトライ回数。ワークフローは1時間おきに動くので、失敗しても次回実行時にリトライされる
+  ogFetchRetryCount: 1, // OGP取得のリトライ回数。ワークフローは1時間おきに動くので、失敗しても次回実行時にリトライされる
 };

--- a/src/feed/feed-crawler.ts
+++ b/src/feed/feed-crawler.ts
@@ -67,10 +67,13 @@ export class FeedCrawler {
     aggregateFeedStartAt: Date,
   ): Promise<ClawlFeedsResult> {
     // フィード取得してまとめる
+    const fetchFeedsStartTime = Date.now();
     const feeds = await this.fetchFeedsAsync(feedInfoList, feedFetchConcurrency);
     const allFeedItems = this.aggregateFeeds(feeds, aggregateFeedStartAt);
+    logger.info('[phase] fetch feeds', `${((Date.now() - fetchFeedsStartTime) / 1000).toFixed(1)}s`);
 
     // OGPなどの情報取得
+    const fetchOgAndHatenaStartTime = Date.now();
     const [errorFetchFeedData, results] = await to(
       Promise.all([
         this.fetchFeedItemOgObjectMap(allFeedItems, feedOgFetchConcurrency),
@@ -78,6 +81,7 @@ export class FeedCrawler {
         this.fetchFeedBlogOgObjectMap(feeds, feedOgFetchConcurrency),
       ]),
     );
+    logger.info('[phase] fetch og/hatena', `${((Date.now() - fetchOgAndHatenaStartTime) / 1000).toFixed(1)}s`);
     if (errorFetchFeedData) {
       throw new Error('フィード関連データの取得に失敗しました');
     }
@@ -107,40 +111,44 @@ export class FeedCrawler {
       .withConcurrency(concurrency)
       .process(async (feedInfo) => {
         const [error, feed] = await to(
-          exponentialBackoff(async (attemptCount: number) => {
-            if (attemptCount > 0) {
-              logger.warn(`[fetch-feed] retry ${feedInfo.url}`);
-            }
-
-            const feedCacheKey = `feed-${textToMd5Hash(feedInfo.url)}`;
-            const feedCache = flatCacheCreate({
-              cacheId: feedCacheKey,
-              ttl: constants.fetchedFeedCacheDurationInHours * 60 * 60 * 1000,
-            });
-            const cachedData = feedCache.get<string>(feedCacheKey);
-            let feedData: string;
-
-            if (cachedData) {
-              logger.trace('[fetch-feed] cache hit', feedInfo.label, feedInfo.url);
-              feedData = cachedData;
-            } else {
-              const response = await fetch(feedInfo.url, {
-                signal: AbortSignal.timeout(1000 * 10),
-              });
-              if (!response.ok) {
-                throw new Error(`HTTP Error: ${response.status}`);
+          exponentialBackoff(
+            async (attemptCount: number) => {
+              if (attemptCount > 0) {
+                logger.warn(`[fetch-feed] retry ${feedInfo.url}`);
               }
-              feedData = await response.text();
 
-              // バリデーション
-              await this.feedValidator.assertXmlFeed('fetched-feed', feedData);
+              const feedCacheKey = `feed-${textToMd5Hash(feedInfo.url)}`;
+              const feedCache = flatCacheCreate({
+                cacheId: feedCacheKey,
+                ttl: constants.fetchedFeedCacheDurationInHours * 60 * 60 * 1000,
+              });
+              const cachedData = feedCache.get<string>(feedCacheKey);
+              let feedData: string;
 
-              feedCache.set(feedCacheKey, feedData);
-              feedCache.save();
-            }
+              if (cachedData) {
+                logger.trace('[fetch-feed] cache hit', feedInfo.label, feedInfo.url);
+                feedData = cachedData;
+              } else {
+                const response = await fetch(feedInfo.url, {
+                  signal: AbortSignal.timeout(1000 * 10),
+                });
+                if (!response.ok) {
+                  throw new Error(`HTTP Error: ${response.status}`);
+                }
+                feedData = await response.text();
 
-            return this.rssParser.parseString(feedData) as Promise<CustomRssParserFeed>;
-          }),
+                // バリデーション
+                await this.feedValidator.assertXmlFeed('fetched-feed', feedData);
+
+                feedCache.set(feedCacheKey, feedData);
+                feedCache.save();
+              }
+
+              return this.rssParser.parseString(feedData) as Promise<CustomRssParserFeed>;
+            },
+            1000,
+            constants.feedFetchRetryCount,
+          ),
         );
         if (error) {
           logger.error(
@@ -327,13 +335,17 @@ export class FeedCrawler {
       .withConcurrency(concurrency)
       .process(async (feedItem) => {
         const [error, ogObject] = await to(
-          exponentialBackoff((attemptCount: number) => {
-            if (attemptCount > 0) {
-              logger.warn(`[fetch-feed-item-og] retry ${feedItem.link}`);
-            }
+          exponentialBackoff(
+            (attemptCount: number) => {
+              if (attemptCount > 0) {
+                logger.warn(`[fetch-feed-item-og] retry ${feedItem.link}`);
+              }
 
-            return FeedCrawler.fetchOgObject(feedItem.link);
-          }),
+              return FeedCrawler.fetchOgObject(feedItem.link);
+            },
+            1000,
+            constants.ogFetchRetryCount,
+          ),
         );
         if (error) {
           logger.error(
@@ -364,13 +376,17 @@ export class FeedCrawler {
       .withConcurrency(concurrency)
       .process(async (feed) => {
         const [error, ogObject] = await to(
-          exponentialBackoff((attemptCount: number) => {
-            if (attemptCount > 0) {
-              logger.warn(`[fetch-feed-blog-og] retry ${feed.link}`);
-            }
+          exponentialBackoff(
+            (attemptCount: number) => {
+              if (attemptCount > 0) {
+                logger.warn(`[fetch-feed-blog-og] retry ${feed.link}`);
+              }
 
-            return FeedCrawler.fetchOgObject(feed.link);
-          }),
+              return FeedCrawler.fetchOgObject(feed.link);
+            },
+            1000,
+            constants.ogFetchRetryCount,
+          ),
         );
         if (error) {
           logger.error('[fetch-feed-blog-og] error', `${fetchProcessCounter++}/${feedsLength}`, feed.title, feed.link);

--- a/src/feed/prune-cache.ts
+++ b/src/feed/prune-cache.ts
@@ -1,0 +1,76 @@
+import type { Dirent } from 'node:fs';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+
+export interface PruneCacheDirResult {
+  dir: string;
+  deletedFileCount: number;
+  freedBytes: number;
+}
+
+export interface PruneCacheResult {
+  dirResults: PruneCacheDirResult[];
+  totalDeletedFileCount: number;
+  totalFreedBytes: number;
+}
+
+/**
+ * 指定したディレクトリ群から、mtime が maxAgeInDays より古いファイルを再帰的に削除する。
+ * ディレクトリ自体は削除しない。対象ディレクトリが存在しない場合はスキップする。
+ */
+export const pruneCache = async (dirs: string[], maxAgeInDays: number): Promise<PruneCacheResult> => {
+  const thresholdMs = Date.now() - maxAgeInDays * 24 * 60 * 60 * 1000;
+
+  const dirResults: PruneCacheDirResult[] = [];
+  for (const dir of dirs) {
+    dirResults.push(await pruneDir(dir, dir, thresholdMs));
+  }
+
+  const totalDeletedFileCount = dirResults.reduce((sum, result) => sum + result.deletedFileCount, 0);
+  const totalFreedBytes = dirResults.reduce((sum, result) => sum + result.freedBytes, 0);
+
+  return { dirResults, totalDeletedFileCount, totalFreedBytes };
+};
+
+/**
+ * 単一ディレクトリ配下（再帰的）を走査してファイルを削除する
+ */
+const pruneDir = async (rootDir: string, currentDir: string, thresholdMs: number): Promise<PruneCacheDirResult> => {
+  let deletedFileCount = 0;
+  let freedBytes = 0;
+
+  let entries: Dirent<string>[];
+  try {
+    entries = await fs.readdir(currentDir, { withFileTypes: true, encoding: 'utf8' });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      // ディレクトリが存在しない場合はスキップ
+      return { dir: rootDir, deletedFileCount, freedBytes };
+    }
+    throw error;
+  }
+
+  for (const entry of entries) {
+    const entryPath = path.join(currentDir, entry.name);
+
+    if (entry.isDirectory()) {
+      const subResult = await pruneDir(rootDir, entryPath, thresholdMs);
+      deletedFileCount += subResult.deletedFileCount;
+      freedBytes += subResult.freedBytes;
+      continue;
+    }
+
+    if (!entry.isFile()) {
+      continue;
+    }
+
+    const stat = await fs.stat(entryPath);
+    if (stat.mtimeMs < thresholdMs) {
+      freedBytes += stat.size;
+      await fs.unlink(entryPath);
+      deletedFileCount++;
+    }
+  }
+
+  return { dir: rootDir, deletedFileCount, freedBytes };
+};

--- a/tests/prune-cache.test.ts
+++ b/tests/prune-cache.test.ts
@@ -1,0 +1,104 @@
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { pruneCache } from '../src/feed/prune-cache';
+
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+describe('pruneCache', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'prune-cache-test-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  const writeFileWithMtime = async (filePath: string, mtimeMs: number, content = 'x') => {
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(filePath, content);
+    const mtime = new Date(mtimeMs);
+    await fs.utimes(filePath, mtime, mtime);
+  };
+
+  it('mtimeが古いファイルを削除し、新しいファイルは残す', async () => {
+    const dir = path.join(tempDir, 'cache-dir');
+    const oldFile = path.join(dir, 'old-file.txt');
+    const freshFile = path.join(dir, 'fresh-file.txt');
+
+    await writeFileWithMtime(oldFile, Date.now() - 15 * ONE_DAY_MS, 'old-content');
+    await writeFileWithMtime(freshFile, Date.now() - 1 * ONE_DAY_MS, 'fresh-content');
+
+    const result = await pruneCache([dir], 14);
+
+    await expect(fs.access(oldFile)).rejects.toThrow();
+    await expect(fs.access(freshFile)).resolves.toBeUndefined();
+
+    expect(result.totalDeletedFileCount).toEqual(1);
+    expect(result.totalFreedBytes).toEqual(Buffer.byteLength('old-content'));
+    expect(result.dirResults).toEqual([
+      {
+        dir,
+        deletedFileCount: 1,
+        freedBytes: Buffer.byteLength('old-content'),
+      },
+    ]);
+  });
+
+  it('サブディレクトリも再帰的に走査し、ディレクトリ自体は削除しない', async () => {
+    const dir = path.join(tempDir, 'cache-dir');
+    const nestedOldFile = path.join(dir, 'nested', 'old-file.txt');
+    const nestedFreshFile = path.join(dir, 'nested', 'fresh-file.txt');
+
+    await writeFileWithMtime(nestedOldFile, Date.now() - 20 * ONE_DAY_MS);
+    await writeFileWithMtime(nestedFreshFile, Date.now());
+
+    const result = await pruneCache([dir], 14);
+
+    await expect(fs.access(nestedOldFile)).rejects.toThrow();
+    await expect(fs.access(nestedFreshFile)).resolves.toBeUndefined();
+    // ディレクトリ自体は削除されず残っている
+    await expect(fs.access(path.join(dir, 'nested'))).resolves.toBeUndefined();
+
+    expect(result.totalDeletedFileCount).toEqual(1);
+  });
+
+  it('存在しないディレクトリはスキップしてエラーにならない', async () => {
+    const missingDir = path.join(tempDir, 'does-not-exist');
+
+    const result = await pruneCache([missingDir], 14);
+
+    expect(result.totalDeletedFileCount).toEqual(0);
+    expect(result.totalFreedBytes).toEqual(0);
+    expect(result.dirResults).toEqual([{ dir: missingDir, deletedFileCount: 0, freedBytes: 0 }]);
+  });
+
+  it('複数ディレクトリを処理し、統計を合算する', async () => {
+    const dirA = path.join(tempDir, 'dir-a');
+    const dirB = path.join(tempDir, 'dir-b');
+
+    await writeFileWithMtime(path.join(dirA, 'old.txt'), Date.now() - 30 * ONE_DAY_MS, 'aaaa');
+    await writeFileWithMtime(path.join(dirB, 'old.txt'), Date.now() - 30 * ONE_DAY_MS, 'bb');
+
+    const result = await pruneCache([dirA, dirB], 14);
+
+    expect(result.totalDeletedFileCount).toEqual(2);
+    expect(result.totalFreedBytes).toEqual(Buffer.byteLength('aaaa') + Buffer.byteLength('bb'));
+  });
+
+  it('閾値ちょうどのしきい値より新しいファイルは削除しない', async () => {
+    const dir = path.join(tempDir, 'cache-dir');
+    const justInsideThreshold = path.join(dir, 'inside.txt');
+
+    // 13日前は14日しきい値より新しいので残る
+    await writeFileWithMtime(justInsideThreshold, Date.now() - 13 * ONE_DAY_MS);
+
+    const result = await pruneCache([dir], 14);
+
+    await expect(fs.access(justInsideThreshold)).resolves.toBeUndefined();
+    expect(result.totalDeletedFileCount).toEqual(0);
+  });
+});


### PR DESCRIPTION
## Summary

The scheduled feed job spends ~40s per run just restoring/saving the feed cache, which has grown to **2.37GB**. Root cause: flat-cache creates one file per URL (`og-object-<md5>` per article URL, kept forever), and eleventy-fetch buffers / generated thumbnails are never cleaned up either.

This PR adds cache pruning, reduces fetch retries, and adds phase timing logs.

## Changes

### 1. Cache pruning (`npm run cache-prune`)
- New CLI (`src/cli/prune-cache-command.ts` + `src/feed/prune-cache.ts`) that deletes files older than 14 days (by mtime) from `.cache`, `public/images/feed-thumbnails`, and `public/images/feed-icons`.
- Safety rationale: active cache entries are rewritten regularly (feeds hourly, OGP every 24h while the article is inside the 8-day aggregation window, eleventy-fetch buffers every 3 days), so anything untouched for 14 days is dead. Generated images may keep old mtimes while still referenced, but the prune step runs **right after cache restore and before `site-prepare`/`site-build`**, so anything over-pruned is regenerated within the same run (self-healing).
- Wired into `generate-feed.yml` after `restore-feed-cache`.

### 2. Fetch retries: 3 → 1
- The workflow runs hourly, so a failed feed/OGP fetch is naturally retried on the next run. With a 10s timeout + exponential backoff, a single dead URL could previously stall its phase for up to ~47s; now the worst case is ~21s.

### 3. Phase timing logs
- `[phase] fetch feeds` / `[phase] fetch og/hatena` / `[phase] generate + store + validate feeds` at info level, so future bottlenecks can be measured instead of guessed.

## Expected impact

- Cache restore/save: ~40s → a few seconds once the cache shrinks (first run after merge does the big prune).
- `feed-generate` (currently ~62s): shorter tail whenever dead feeds are present.

## Test plan

- [x] `npm run test-internal` — 56 tests passing (5 new unit tests for `pruneCache`: stale/fresh split, recursion, missing dir, multi-dir stats, threshold boundary)
- [x] `npm run lint` (biome / tsc / secretlint) clean
- [x] `npm run cache-prune` runs locally and logs per-directory stats
- [ ] After merge: check the scheduled run's cache size and step durations

🤖 Generated with [Claude Code](https://claude.com/claude-code)