### PR TITLE
Issue #362 JTPのフィード取得エラーの対応

### DIFF
--- a/src/resources/feed-info-list.ts
+++ b/src/resources/feed-info-list.ts
@@ -147,7 +147,7 @@ export const FEED_INFO_LIST: FeedInfo[] = createFeedInfoList([
   ['Insight Edge', 'https://techblog.insightedge.jp/feed'],
   ['JCB', 'https://tech.jcblab.jp/feed'],
   ['JMDC', 'https://techblog.jmdc.co.jp/feed'],
-  ['JTP', 'https://tech-blog.jtp.co.jp/feed'],
+  // ['JTP', 'https://tech-blog.jtp.co.jp/feed'],// 2026-09 取得エラー継続のため除外: はてなブログ独自ドメイン解約跡地で接続不可。移行先のRSSフィード提供なし
   ['JX通信社', 'https://tech.jxpress.net/feed'],
   ['KAIZEN PLATFORM', 'https://developer.kaizenplatform.com/feed'],
   ['KARAKURI', 'https://medium.com/feed/karakuri'],


### PR DESCRIPTION
## 概要
JTP の企業テックブログ (`https://tech-blog.jtp.co.jp/feed`) の
フィード取得が失敗するため、対象エントリを削除します。

## 背景
- Issue #362 で、9/2 以降フィードが更新されていない不具合が報告されていました
- 旧サイト（はてなブログ、tech-blog.jtp.co.jp）は
新サイト「JTP Technology Port」(https://solution.jtp.co.jp/blog) に
  移行済みですが、確認した限りRSSフィードの提供が無いため、
  現状の仕組みでは代替の取得先を設定できません

## 対応
`feed-info-list.ts` から JTP のエントリを削除しました。
新サイトでRSS提供が再開された場合は、改めて以下の情報の反映が必要です。

- 企業名 : JTP
- ブログURL : https://solution.jtp.co.jp/blog)
- RSSフィードURL

なお、Issue #362には、もう1つのエラーについて言及されています。こちらは原因が異なるため、
この対応には含んでいません。