### PR TITLE
fix(site):  restore article thumbnails

### DIFF
--- a/src/site/_includes/components/feed-item.ts
+++ b/src/site/_includes/components/feed-item.ts
@@ -15,7 +15,7 @@ export const renderFeedItem = async (
   const relativeUrl = escapeHtml(rawRelativeUrl);
 
   const ogImage = feedItem.image
-    ? await imageThumbnailShortcode(feedItem.image.url, '記事のアイキャッチ画像', rawRelativeUrl, imageLoading)
+    ? await imageThumbnailShortcode(feedItem.image, '記事のアイキャッチ画像', rawRelativeUrl, imageLoading)
     : `<img src='${relativeUrl}images/alternate-feed-image.png' loading="${escapeHtml(imageLoading)}" alt='記事のアイキャッチ画像' width='256' height='256'>`;
 
   const hatenaCount =

--- a/src/site/_includes/components/types.ts
+++ b/src/site/_includes/components/types.ts
@@ -40,10 +40,7 @@ export interface FeedJsonItem {
   url: string;
   title?: string;
   summary?: string;
-  image?: {
-    url: string;
-    alt?: string;
-  };
+  image?: string;
   date_modified?: string;
   date_published?: string;
   tags?: string[];


### PR DESCRIPTION
## 概要

Fixes: #361

`feed`v6からJSON Feedの`image`が`{ url }`ではなくURL文字列で出力されるようになりました。
表示側はこれまで`feedItem.image.url`を参照していたため、画像URLが渡らず、すべての記事でプレースホルダー画像になっていました。

`image`を文字列のままサムネイル生成処理に渡すように変更しています。
