### PR TITLE
fix(feed):  use article link when guid is not a URL

### DIFF
--- a/src/feed/feed-generator.ts
+++ b/src/feed/feed-generator.ts
@@ -73,7 +73,12 @@ export class FeedGenerator {
     for (const feedItem of feedItems) {
       logger.info('[create-feed-item]', feedItem.isoDate, feedItem.title);
 
-      const feedItemId = feedItem.guid || feedItem.link;
+      // AtomのidはURLとして扱われるため、URLでないguidは使わない
+      if (!isValidHttpUrl(feedItem.link)) {
+        logger.warn('[feed-item] フィードのリンクが不正です。', feedItem.link, feedItem.title);
+        continue;
+      }
+      const feedItemId = feedItem.guid && isValidHttpUrl(feedItem.guid) ? feedItem.guid : feedItem.link;
       const feedItemContent = (feedItem.summary || feedItem.contentSnippet || '').replace(/(\n|\t+|\s+)/g, ' ');
 
       const ogObject = feedItemOgObjectMap.get(feedItem.link);

--- a/tests/feed-generator.test.ts
+++ b/tests/feed-generator.test.ts
@@ -30,4 +30,47 @@ describe('FeedGenerator', () => {
     expect(result.aggregatedFeed.items[0].image).toBeUndefined();
     expect(result.feedDistributionSet.atom).toContain('<feed');
   });
+
+  it('URLでないguidはlinkをidにしてAtomフィードを生成できる', () => {
+    const feedItem = {
+      title: 'テスト記事',
+      link: 'https://example.com/test-article/',
+      guid: '6a853e4d08752169b9ab7316',
+      isoDate: '2026-06-09T04:03:10.000Z',
+      blogTitle: 'Example Tech Blog',
+      blogLink: 'https://example.com',
+    } as CustomRssParserItem;
+    const feedGenerator = new FeedGenerator();
+
+    const result = feedGenerator.generateFeeds([feedItem], new Map(), new Map(), 200, 500);
+
+    expect(result.aggregatedFeed.items[0].id).toEqual('https://example.com/test-article/');
+    expect(result.feedDistributionSet.atom).toContain('<id>https://example.com/test-article/</id>');
+  });
+
+  it('不正なリンクのitemはスキップしてフィード生成できる', () => {
+    const invalidItem = {
+      title: 'テスト記事',
+      link: 'not-a-url',
+      guid: '6a853e4d08752169b9ab7316',
+      isoDate: '2026-06-09T04:03:10.000Z',
+      blogTitle: 'Example Tech Blog',
+      blogLink: 'https://example.com',
+    } as CustomRssParserItem;
+    const validItem = {
+      title: 'テスト記事',
+      link: 'https://example.com/test-article/',
+      guid: 'https://example.com/?p=1',
+      isoDate: '2026-06-09T04:03:10.000Z',
+      blogTitle: 'Example Tech Blog',
+      blogLink: 'https://example.com',
+    } as CustomRssParserItem;
+    const feedGenerator = new FeedGenerator();
+
+    const result = feedGenerator.generateFeeds([invalidItem, validItem], new Map(), new Map(), 200, 500);
+
+    expect(result.aggregatedFeed.items).toHaveLength(1);
+    expect(result.aggregatedFeed.items[0].link).toEqual('https://example.com/test-article/');
+    expect(result.feedDistributionSet.atom).toContain('<feed');
+  });
 });


### PR DESCRIPTION
## 概要

#362 の対応になります。

#361 の修正時にローカルで再現できたため修正しました。

`feed` v6からAtom出力時にentryの`id`を`new URL()`で検証するようになったようです。
（以下の`Improved sanitization - sanitizeUrl() validates and normalizes URLs`）
https://github.com/jpmonette/feed/pull/252

一部の記事の`guid`はURLではないハッシュ値のため、`TypeError: Invalid URL`でフィード生成全体が失敗しています。

`guid`がURLでない場合は記事の`link`を`id`に使い`link`自体が不正な記事はスキップすることで対応しました。

再現時のログは以下になります。
```text
[2026-09-07T19:58:39.364] [INFO] default - [create-feed] finished node:internal/url:819
      href = bindingUrl.parse(input, base, true);
                        ^

TypeError: Invalid URL
    at new URL (node:internal/url:819:25)
    at sanitizeUrl (file:///Users/akk/Project/tech-blog-rss-feed/node_modules/feed/lib/feed.js:18:17)
    at file:///Users/akk/Project/tech-blog-rss-feed/node_modules/feed/lib/feed.js:79:8
    at Array.forEach (<anonymous>
)
    at atom1_default (file:///Users/akk/Project/tech-blog-rss-feed/node_modules/feed/lib/feed.js:73:12)
    at Feed.atom1 (file:///Users/akk/Project/tech-blog-rss-feed/node_modules/feed/lib/feed.js:411:10)
    at FeedGenerator.generateFeeds (/Users/akk/Project/tech-blog-rss-feed/src/feed/feed-generator.ts:45:46)
    at <anonymous>
 (/Users/akk/Project/tech-blog-rss-feed/src/cli/generate-feed-command.ts:35:45)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5) {
  code: 'ERR_INVALID_URL',
  input: '6a853e4d08752169b9ab7316' }
```

### テスト

```bash
npm test -- tests/feed-generator.test.ts
```

### 関連リンク

- https://github.com/yamadashy/tech-blog-rss-feed/pull/351
- https://github.com/jpmonette/feed/releases/tag/6.0.0
- https://github.com/jpmonette/feed/pull/252