### PR TITLE
fix: use import attributes ('with') instead of import assertions

### DIFF
--- a/src/cli/prepare-site-command.ts
+++ b/src/cli/prepare-site-command.ts
@@ -5,7 +5,7 @@ import { imageThumbnailShortcode } from '../common/eleventy-utils';
 import type { BlogFeed } from '../feed/feed-storer';
 import { logger } from '../feed/logger';
 // @ts-ignore
-import blogFeeds from '../site/blog-feeds/blog-feeds.json' assert { type: 'json' };
+import blogFeeds from '../site/blog-feeds/blog-feeds.json' with { type: 'json' };
 
 const typedBlogFeeds: BlogFeed[] = blogFeeds as BlogFeed[];
 


### PR DESCRIPTION
## Summary
- Replace `assert { type: 'json' }` with `with { type: 'json' }` in `src/cli/prepare-site-command.ts`.
- TypeScript 7 removes support for the legacy import-assertion syntax (`TS2880`), which is why `Lint TypeScript` fails on #352. Node >= 24 (this repo's engine) supports import attributes.

## Verification
- `npm run lint-ts` / `npm run lint-biome` pass locally on TypeScript 6.0.3
- `tsx` runtime import of `blog-feeds.json` with the new syntax works
- Unit tests pass (only the network-bound `tests/external` suite times out locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)