### PR TITLE
fix(ts): switch moduleResolution to bundler for TypeScript 7

### DIFF
--- a/src/feed/feed-crawler.ts
+++ b/src/feed/feed-crawler.ts
@@ -4,7 +4,7 @@ import { to } from 'await-to-js';
 import dayjs from 'dayjs';
 import { create as flatCacheCreate } from 'flat-cache';
 import { default as ogs } from 'open-graph-scraper';
-import type { ImageObject, OgObject, OpenGraphScraperOptions } from 'open-graph-scraper/types/lib/types';
+import type { ImageObject, OgObject, OpenGraphScraperOptions } from 'open-graph-scraper/types';
 import RssParser from 'rss-parser';
 import constants from '../common/constants';
 import type { FeedInfo } from '../resources/feed-info-list';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "strict": true,
     "target": "es2021",
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "ignoreDeprecations": "6.0",
     "esModuleInterop": true,
     "lib": ["dom", "esnext"],


### PR DESCRIPTION
## Summary
- `tsconfig.json`: `moduleResolution: node` → `bundler`. TypeScript 7 removes the legacy `node10` resolution (`TS5108`), which is the remaining failure on #352.
- `src/feed/feed-crawler.ts`: import `open-graph-scraper` types from its public `./types` export instead of the internal `types/lib/types` path, since `bundler` enforces package `exports`.

Type-only changes; runtime (tsx / eleventy) is unaffected.

## Verification
- `tsc --noEmit` passes on TypeScript 6.0.3 (current) and 7.x (`npx -p typescript@7`)
- `npm run lint-biome` and unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)