### PR TITLE
perf(build): speed up the hourly generate workflow

### DIFF
--- a/eleventy.config.ts
+++ b/eleventy.config.ts
@@ -1,3 +1,4 @@
+import EleventyFetch from '@11ty/eleventy-fetch';
 import EleventyImage from '@11ty/eleventy-img';
 import constants from './src/common/constants';
 import {
@@ -8,6 +9,8 @@ import {
   relativeUrlFilter,
 } from './src/common/eleventy-utils';
 
+// eleventy-fetch のキューはグローバル設定（既定 10）。呼び出しごとの concurrency オプションでは変わらない
+EleventyFetch.concurrency = constants.eleventyFetchConcurrency;
 EleventyImage.concurrency = constants.eleventyFetchConcurrency;
 
 // biome-ignore lint/suspicious/noExplicitAny: This is intentional

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "cache-prune": "tsx src/cli/prune-cache-command.ts",
     "register-index": "tsx src/cli/register-index-command.ts",
     "site-prepare": "tsx src/cli/prepare-site-command.ts",
-    "site-build": "tsx ./node_modules/.bin/eleventy --config=eleventy.config.ts",
+    "site-build": "tsx src/cli/build-site-command.ts",
     "site-serve": "tsx ./node_modules/.bin/eleventy --config=eleventy.config.ts --serve",
     "lint": "npm run lint-biome && npm run lint-ts && npm run lint-secretlint",
     "lint-biome": "biome check --write",

--- a/src/@types/eleventy-fetch.d.ts
+++ b/src/@types/eleventy-fetch.d.ts
@@ -20,5 +20,10 @@ declare module '@11ty/eleventy-fetch' {
   export function EleventyFetch<T>(url: string, options: EleventyFetchOptions<'json'>): Promise<T>;
   export function EleventyFetch(url: string, options: EleventyFetchOptions<'text'>): Promise<string>;
 
+  export namespace EleventyFetch {
+    // グローバルなフェッチキューの並列数（既定 10）
+    let concurrency: number;
+  }
+
   export default EleventyFetch;
 }

--- a/src/@types/eleventy.d.ts
+++ b/src/@types/eleventy.d.ts
@@ -1,0 +1,14 @@
+declare module '@11ty/eleventy' {
+  export interface EleventyOptions {
+    configPath?: string;
+    quietMode?: boolean;
+    source?: 'cli' | 'script';
+    runMode?: 'build' | 'watch' | 'serve';
+    dryRun?: boolean;
+  }
+
+  export default class Eleventy {
+    constructor(input?: string, output?: string, options?: EleventyOptions);
+    write(): Promise<unknown>;
+  }
+}

--- a/src/cli/build-site-command.ts
+++ b/src/cli/build-site-command.ts
@@ -1,0 +1,23 @@
+import Eleventy from '@11ty/eleventy';
+
+/**
+ * Eleventy でサイトをビルドする。
+ * CLI（`eleventy --config=...`）ではなくプログラマティック API を使うのは、ビルド完了後に明示的にプロセスを終了するため。
+ * 画像取得後に残る TCP ソケットがイベントループを保持し、CLI だと書き出し完了後も 10〜20 秒プロセスが終了しない
+ */
+(async () => {
+  const eleventy = new Eleventy(undefined, undefined, {
+    configPath: 'eleventy.config.ts',
+    source: 'cli',
+  });
+
+  await eleventy.write();
+})().then(
+  () => {
+    process.exit(0);
+  },
+  (error) => {
+    console.error(error);
+    process.exit(1);
+  },
+);

--- a/src/cli/prepare-site-command.ts
+++ b/src/cli/prepare-site-command.ts
@@ -1,3 +1,5 @@
+import EleventyFetch from '@11ty/eleventy-fetch';
+import EleventyImage from '@11ty/eleventy-img';
 import { PromisePool } from '@supercharge/promise-pool';
 import { to } from 'await-to-js';
 import constants from '../common/constants';
@@ -8,6 +10,10 @@ import { logger } from '../feed/logger';
 import blogFeeds from '../site/blog-feeds/blog-feeds.json' with { type: 'json' };
 
 const typedBlogFeeds: BlogFeed[] = blogFeeds as BlogFeed[];
+
+// eleventy-fetch のキューはグローバル設定（既定 10）。呼び出しごとの concurrency オプションでは変わらない
+EleventyFetch.concurrency = constants.eleventyFetchConcurrency;
+EleventyImage.concurrency = constants.eleventyFetchConcurrency;
 
 /**
  * サイトの前準備処理。Eleventyの高速化のための処理なので実行しなくても問題はない
@@ -41,4 +47,13 @@ const typedBlogFeeds: BlogFeed[] = blogFeeds as BlogFeed[];
 
       logger.info('[process-og-image] fetched', `${fetchProcessCounter++}/${ogImageUrlsLength}`, ogImageUrl);
     });
-})();
+})().then(
+  () => {
+    // 画像取得後に残る TCP ソケットがイベントループを保持し、処理完了後も 10〜20 秒プロセスが終了しないため明示的に終了する
+    process.exit(0);
+  },
+  (error) => {
+    console.error(error);
+    process.exit(1);
+  },
+);

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -41,6 +41,7 @@ export default {
   // 処理の設定
   feedFetchConcurrency: 50, // フィードを取得する並列数
   feedOgFetchConcurrency: 20, // OG情報を取得する並列数
+  hatenaCountFetchConcurrency: 5, // はてなブックマーク数を取得する並列数（50件ずつのチャンク単位）
   aggregateFeedDurationInHours: 8 * 24, // まとめフィードの対象となる時間の範囲
   maxFeedDescriptionLength: 200, // フィードのdescriptionの最大文字数
   maxFeedContentLength: 500, // フィードのcontentの最大文字数

--- a/src/feed/common-util.ts
+++ b/src/feed/common-util.ts
@@ -78,7 +78,9 @@ export const exponentialBackoff = async <A>(
 
 export const fetchHatenaCountMap = async (urls: string[]): Promise<HatenaCountMap> => {
   const params = urls.map((url) => `url=${url}`).join('&');
-  const response = await axios.get<HatenaCountMap>(`https://bookmark.hatenaapis.com/count/entries?${params}`);
+  const response = await axios.get<HatenaCountMap>(`https://bookmark.hatenaapis.com/count/entries?${params}`, {
+    timeout: 1000 * 10,
+  });
   return response.data;
 };
 

--- a/src/feed/feed-crawler.ts
+++ b/src/feed/feed-crawler.ts
@@ -123,28 +123,31 @@ export class FeedCrawler {
                 ttl: constants.fetchedFeedCacheDurationInHours * 60 * 60 * 1000,
               });
               const cachedData = feedCache.get<string>(feedCacheKey);
-              let feedData: string;
 
               if (cachedData) {
                 logger.trace('[fetch-feed] cache hit', feedInfo.label, feedInfo.url);
-                feedData = cachedData;
-              } else {
-                const response = await fetch(feedInfo.url, {
-                  signal: AbortSignal.timeout(1000 * 10),
-                });
-                if (!response.ok) {
-                  throw new Error(`HTTP Error: ${response.status}`);
-                }
-                feedData = await response.text();
-
-                // バリデーション
-                await this.feedValidator.assertXmlFeed('fetched-feed', feedData);
-
-                feedCache.set(feedCacheKey, feedData);
-                feedCache.save();
+                return this.rssParser.parseString(cachedData) as Promise<CustomRssParserFeed>;
               }
 
-              return this.rssParser.parseString(feedData) as Promise<CustomRssParserFeed>;
+              const response = await fetch(feedInfo.url, {
+                signal: AbortSignal.timeout(1000 * 10),
+              });
+              if (!response.ok) {
+                throw new Error(`HTTP Error: ${response.status}`);
+              }
+              const feedData = await response.text();
+
+              // バリデーション。パース結果をそのまま使うことで同じ XML を二度パースしない
+              const parsedFeed = (await this.feedValidator.assertXmlFeed(
+                'fetched-feed',
+                feedData,
+                this.rssParser,
+              )) as CustomRssParserFeed;
+
+              feedCache.set(feedCacheKey, feedData);
+              feedCache.save();
+
+              return parsedFeed;
             },
             1000,
             constants.feedFetchRetryCount,
@@ -498,19 +501,22 @@ export class FeedCrawler {
       feedItemCounter++;
     }
 
-    for (const feedItemUrls of feedItemUrlsChunks) {
-      const [error, hatenaCountMap] = await to(fetchHatenaCountMap(feedItemUrls));
+    // チャンクごとに並列で取得。失敗したチャンクはスキップして他のチャンクは続行する
+    await PromisePool.for(feedItemUrlsChunks)
+      .withConcurrency(constants.hatenaCountFetchConcurrency)
+      .process(async (feedItemUrls) => {
+        const [error, hatenaCountMap] = await to(fetchHatenaCountMap(feedItemUrls));
 
-      if (error) {
-        logger.error('[fetch-feed-item-hatena-count] error');
-        logger.trace(error);
-        continue;
-      }
+        if (error) {
+          logger.error('[fetch-feed-item-hatena-count] error');
+          logger.trace(error);
+          return;
+        }
 
-      for (const feedItemUrl in hatenaCountMap) {
-        feedItemHatenaCountMap.set(feedItemUrl, hatenaCountMap[feedItemUrl]);
-      }
-    }
+        for (const feedItemUrl in hatenaCountMap) {
+          feedItemHatenaCountMap.set(feedItemUrl, hatenaCountMap[feedItemUrl]);
+        }
+      });
 
     logger.info('[fetch-feed-item-hatena-count] fetched', feedItemHatenaCountMap);
 

--- a/src/feed/feed-validator.ts
+++ b/src/feed/feed-validator.ts
@@ -21,11 +21,17 @@ export class FeedValidator {
     }
   }
 
-  public async assertXmlFeed(label: string, feedXml: string): Promise<void> {
-    const rssParser = new RssParser();
-
+  /**
+   * XML フィードを検証し、検証の過程で得た rss-parser のパース結果を返す
+   * （呼び出し側で同じ XML をもう一度パースしなくて済むようにするため）
+   */
+  public async assertXmlFeed(
+    label: string,
+    feedXml: string,
+    rssParser: RssParser = new RssParser(),
+  ): Promise<RssParser.Output<RssParser.Item>> {
     // rss-parser で変換してみてエラーが出ないか確認
-    const [rssParserError] = await to(rssParser.parseString(feedXml));
+    const [rssParserError, parsedFeed] = await to(rssParser.parseString(feedXml));
     if (rssParserError) {
       throw new Error(
         `rss-parserによるフィードのバリデーションエラーです。 label: ${label}, error: ${rssParserError}}`,
@@ -52,5 +58,7 @@ export class FeedValidator {
     if (invalidControlCharsRegex.test(feedXml)) {
       throw new Error(`フィードに不正な制御文字が含まれています。 label: ${label}`);
     }
+
+    return parsedFeed;
   }
 }


### PR DESCRIPTION
## 概要

1 時間おきに走る "Generate feeds and site" ワークフロー（直近 2 分 45 秒）の高速化。

計測したところ `site-prepare` と `site-build` は作業完了後もプロセスが 10〜20 秒終了せず（画像取得後に残る TCP ソケットがイベントループを保持）、合計 33 秒ほど待っているだけの時間がありました。あわせて feed 生成側の無駄も削っています。

### 変更

- `site-prepare` / `site-build`: 作業完了後に `process.exit(0)`（失敗時は非ゼロ終了）。`site-build` は終了を制御するため Eleventy をプログラマティック API で呼ぶ `src/cli/build-site-command.ts` に置き換え
- フィード取得: バリデーション時の rss-parser のパース結果を再利用し、同じ XML を二度パースしない
- はてなブックマーク数: 50 件ずつのチャンクを直列 → 並列 5（10 秒タイムアウト付き）。失敗チャンクをスキップする挙動は維持
- `EleventyFetch.concurrency` を明示的に設定。呼び出しごとの `concurrency` オプションではグローバルキューが変わらず、実質 10 のままだった

### ローカル計測

| コマンド | before | after |
|---|---|---|
| site-prepare（キャッシュ温） | 22 秒 | 3.3 秒 |
| site-build | 書き出し完了後 13 秒待ち | 完了直後に終了 |
| はてなブクマ数取得 | 7 秒（CI） | 0.4 秒 |

CI 全体では 2 分 45 秒 → 1 分 50 秒前後を見込んでいます。マージ後の定期実行で確認します。

### 見送ったもの（Codex にも相談した結果）

- 出力が同じならビルドをスキップ: `feedItemsChunks` / `feedItemsHot` が経過日数で表示対象と順位を変えるため、入力 JSON が同じでも出力が変わる
- `.cache` の原画像 buffer を早期削除: eleventy-img は原画像の取得がキャッシュミスだと出力画像も再生成するため逆効果
- `node_modules` 直キャッシュ: 423MB の復元時間で相殺される可能性があり要計測

🤖 Generated with [Claude Code](https://claude.com/claude-code)
